### PR TITLE
Add inline metadata to example scripts

### DIFF
--- a/example/app.py
+++ b/example/app.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "glfw",
+#     "numpy",
+#     "pyopengl",
+#     "requests",
+#     "slimgui",
+# ]
+# ///
 import logging
 import os
 from dataclasses import dataclass

--- a/example/standalone_glfw.py
+++ b/example/standalone_glfw.py
@@ -1,3 +1,13 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "glfw",
+#     "numpy",
+#     "pyopengl",
+#     "requests",
+#     "slimgui",
+# ]
+# ///
 import os
 
 import glfw

--- a/example/standalone_pyglet.py
+++ b/example/standalone_pyglet.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "glfw",
+#     "numpy",
+#     "pyglet",
+#     "pyopengl",
+#     "requests",
+#     "slimgui",
+# ]
+# ///
 """
 Very much beta quality Pyglet example.  Probably buggy but should be a useful starting point.
 


### PR DESCRIPTION
This allows running a script without prior setup, e.g. for users who want to quickly demo slimgui without setting up slimgui dev environment.

Example usage with uv which supports this metadata:

    uv run --script example/app.py

See PEP 723